### PR TITLE
Add connectivity settings screen

### DIFF
--- a/source/main/ui_generated/CMakeLists.txt
+++ b/source/main/ui_generated/CMakeLists.txt
@@ -1,5 +1,6 @@
 SET(SOURCES screens/ui_Screen1.c
     screens/ui_Settings.c
+    screens/ui_Connections.c
     ui.c
     components/ui_comp_hook.c
     ui_helpers.c

--- a/source/main/ui_generated/filelist.txt
+++ b/source/main/ui_generated/filelist.txt
@@ -1,5 +1,6 @@
 screens/ui_Screen1.c
 screens/ui_Settings.c
+screens/ui_Connections.c
 ui.c
 components/ui_comp_hook.c
 ui_helpers.c

--- a/source/main/ui_generated/screens/ui_Connections.c
+++ b/source/main/ui_generated/screens/ui_Connections.c
@@ -1,0 +1,41 @@
+// This file was generated manually for connection settings screen
+// LVGL version: 8.3.11
+
+#include "../ui.h"
+
+void ui_Connections_screen_init(void)
+{
+    ui_Connections = lv_obj_create(NULL);
+    lv_obj_clear_flag(ui_Connections, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_style_bg_color(ui_Connections, lv_color_hex(0x1F1F1F), LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_set_style_bg_opa(ui_Connections, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+    ui_HomeButton = lv_btn_create(ui_Connections);
+    lv_obj_set_size(ui_HomeButton, 80, 40);
+    lv_obj_set_pos(ui_HomeButton, 10, 10);
+    lv_obj_add_event_cb(ui_HomeButton, ui_event_HomeButton, LV_EVENT_ALL, NULL);
+    lv_obj_t * ui_HomeLabel = lv_label_create(ui_HomeButton);
+    lv_label_set_text(ui_HomeLabel, LV_SYMBOL_HOME);
+
+    ui_WiFiLabel = lv_label_create(ui_Connections);
+    lv_label_set_text(ui_WiFiLabel, "WiFi Settings");
+    lv_obj_set_pos(ui_WiFiLabel, 20, 70);
+
+    ui_WiFiSwitch = lv_switch_create(ui_Connections);
+    lv_obj_set_pos(ui_WiFiSwitch, 250, 65);
+
+    ui_BluetoothLabel = lv_label_create(ui_Connections);
+    lv_label_set_text(ui_BluetoothLabel, "Bluetooth Settings");
+    lv_obj_set_pos(ui_BluetoothLabel, 20, 120);
+
+    ui_BTSwitch = lv_switch_create(ui_Connections);
+    lv_obj_set_pos(ui_BTSwitch, 250, 115);
+
+    ui_USBLabel = lv_label_create(ui_Connections);
+    lv_label_set_text(ui_USBLabel, "USB Settings");
+    lv_obj_set_pos(ui_USBLabel, 20, 170);
+
+    ui_USBSwitch = lv_switch_create(ui_Connections);
+    lv_obj_set_pos(ui_USBSwitch, 250, 165);
+}
+

--- a/source/main/ui_generated/screens/ui_Screen1.c
+++ b/source/main/ui_generated/screens/ui_Screen1.c
@@ -181,7 +181,7 @@ void ui_Screen1_screen_init(void)
     lv_obj_set_x(ui_BTStatusConn, 301);
     lv_obj_set_y(ui_BTStatusConn, -2);
     lv_obj_set_align(ui_BTStatusConn, LV_ALIGN_CENTER);
-    lv_obj_add_flag(ui_BTStatusConn, LV_OBJ_FLAG_HIDDEN | LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
+    lv_obj_add_flag(ui_BTStatusConn, LV_OBJ_FLAG_HIDDEN | LV_OBJ_FLAG_ADV_HITTEST | LV_OBJ_FLAG_CLICKABLE);     /// Flags
     lv_obj_clear_flag(ui_BTStatusConn, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_BTStatusDisconn = lv_img_create(ui_TopPanel);
@@ -201,7 +201,7 @@ void ui_Screen1_screen_init(void)
     lv_obj_set_x(ui_USBStatusOK, 356);
     lv_obj_set_y(ui_USBStatusOK, -1);
     lv_obj_set_align(ui_USBStatusOK, LV_ALIGN_CENTER);
-    lv_obj_add_flag(ui_USBStatusOK, LV_OBJ_FLAG_HIDDEN | LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
+    lv_obj_add_flag(ui_USBStatusOK, LV_OBJ_FLAG_HIDDEN | LV_OBJ_FLAG_ADV_HITTEST | LV_OBJ_FLAG_CLICKABLE);     /// Flags
     lv_obj_clear_flag(ui_USBStatusOK, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_USBStatusFail = lv_img_create(ui_TopPanel);
@@ -211,7 +211,7 @@ void ui_Screen1_screen_init(void)
     lv_obj_set_x(ui_USBStatusFail, 356);
     lv_obj_set_y(ui_USBStatusFail, -1);
     lv_obj_set_align(ui_USBStatusFail, LV_ALIGN_CENTER);
-    lv_obj_add_flag(ui_USBStatusFail, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
+    lv_obj_add_flag(ui_USBStatusFail, LV_OBJ_FLAG_ADV_HITTEST | LV_OBJ_FLAG_CLICKABLE);     /// Flags
     lv_obj_clear_flag(ui_USBStatusFail, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_WiFiStatusConn = lv_img_create(ui_TopPanel);
@@ -221,7 +221,7 @@ void ui_Screen1_screen_init(void)
     lv_obj_set_x(ui_WiFiStatusConn, 257);
     lv_obj_set_y(ui_WiFiStatusConn, 0);
     lv_obj_set_align(ui_WiFiStatusConn, LV_ALIGN_CENTER);
-    lv_obj_add_flag(ui_WiFiStatusConn, LV_OBJ_FLAG_HIDDEN | LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
+    lv_obj_add_flag(ui_WiFiStatusConn, LV_OBJ_FLAG_HIDDEN | LV_OBJ_FLAG_ADV_HITTEST | LV_OBJ_FLAG_CLICKABLE);     /// Flags
     lv_obj_clear_flag(ui_WiFiStatusConn, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_WiFiStatusDisconn = lv_img_create(ui_TopPanel);
@@ -231,7 +231,7 @@ void ui_Screen1_screen_init(void)
     lv_obj_set_x(ui_WiFiStatusDisconn, 257);
     lv_obj_set_y(ui_WiFiStatusDisconn, 0);
     lv_obj_set_align(ui_WiFiStatusDisconn, LV_ALIGN_CENTER);
-    lv_obj_add_flag(ui_WiFiStatusDisconn, LV_OBJ_FLAG_ADV_HITTEST);     /// Flags
+    lv_obj_add_flag(ui_WiFiStatusDisconn, LV_OBJ_FLAG_ADV_HITTEST | LV_OBJ_FLAG_CLICKABLE);     /// Flags
     lv_obj_clear_flag(ui_WiFiStatusDisconn, LV_OBJ_FLAG_SCROLLABLE);      /// Flags
 
     ui_ProjectHeadingLabel = lv_label_create(ui_TopPanel);
@@ -414,7 +414,12 @@ void ui_Screen1_screen_init(void)
     lv_obj_add_event_cb(ui_IconDelay, ui_event_IconDelay, LV_EVENT_ALL, NULL);
     lv_obj_add_event_cb(ui_IconReverb, ui_event_IconReverb, LV_EVENT_ALL, NULL);
     lv_obj_add_event_cb(ui_SettingsImage, ui_event_SettingsImage, LV_EVENT_ALL, NULL);
+    lv_obj_add_event_cb(ui_BTStatusConn, ui_event_BTStatusConn, LV_EVENT_ALL, NULL);
     lv_obj_add_event_cb(ui_BTStatusDisconn, ui_event_BTStatusDisconn, LV_EVENT_ALL, NULL);
+    lv_obj_add_event_cb(ui_USBStatusOK, ui_event_USBStatusOK, LV_EVENT_ALL, NULL);
+    lv_obj_add_event_cb(ui_USBStatusFail, ui_event_USBStatusFail, LV_EVENT_ALL, NULL);
+    lv_obj_add_event_cb(ui_WiFiStatusConn, ui_event_WiFiStatusConn, LV_EVENT_ALL, NULL);
+    lv_obj_add_event_cb(ui_WiFiStatusDisconn, ui_event_WiFiStatusDisconn, LV_EVENT_ALL, NULL);
     lv_obj_add_event_cb(ui_PresetHeadingLabel, ui_event_PresetHeadingLabel, LV_EVENT_ALL, NULL);
     lv_obj_add_event_cb(ui_PresetDetailsTextArea, ui_event_PresetDetailsTextArea, LV_EVENT_ALL, NULL);
     lv_obj_add_event_cb(ui_LeftArrow, ui_event_LeftArrow, LV_EVENT_ALL, NULL);

--- a/source/main/ui_generated/ui.c
+++ b/source/main/ui_generated/ui.c
@@ -40,12 +40,17 @@ void ui_event_SettingsImage(lv_event_t * e);
 lv_obj_t * ui_SettingsImage;
 lv_obj_t * ui_TopPanel;
 lv_obj_t * ui_IKLogo;
+void ui_event_BTStatusConn(lv_event_t * e);
 lv_obj_t * ui_BTStatusConn;
 void ui_event_BTStatusDisconn(lv_event_t * e);
 lv_obj_t * ui_BTStatusDisconn;
+void ui_event_USBStatusOK(lv_event_t * e);
 lv_obj_t * ui_USBStatusOK;
+void ui_event_USBStatusFail(lv_event_t * e);
 lv_obj_t * ui_USBStatusFail;
+void ui_event_WiFiStatusConn(lv_event_t * e);
 lv_obj_t * ui_WiFiStatusConn;
+void ui_event_WiFiStatusDisconn(lv_event_t * e);
 lv_obj_t * ui_WiFiStatusDisconn;
 lv_obj_t * ui_ProjectHeadingLabel;
 lv_obj_t * ui_Skins;
@@ -67,6 +72,17 @@ void ui_event_EntryKeyboard(lv_event_t * e);
 lv_obj_t * ui_EntryKeyboard;
 void ui_event_OKTick(lv_event_t * e);
 lv_obj_t * ui_OKTick;
+// SCREEN: ui_Connections
+void ui_Connections_screen_init(void);
+lv_obj_t * ui_Connections;
+void ui_event_HomeButton(lv_event_t * e);
+lv_obj_t * ui_HomeButton;
+lv_obj_t * ui_WiFiLabel;
+lv_obj_t * ui_WiFiSwitch;
+lv_obj_t * ui_BluetoothLabel;
+lv_obj_t * ui_BTSwitch;
+lv_obj_t * ui_USBLabel;
+lv_obj_t * ui_USBSwitch;
 // CUSTOM VARIABLES
 
 // SCREEN: ui_Settings
@@ -401,12 +417,59 @@ void ui_event_SettingsImage(lv_event_t * e)
     }
 }
 
-void ui_event_BTStatusDisconn(lv_event_t * e)
+void ui_event_BTStatusConn(lv_event_t * e)
 {
     lv_event_code_t event_code = lv_event_get_code(e);
 
+    if(event_code == LV_EVENT_CLICKED) {
+        _ui_screen_change(&ui_Connections, LV_SCR_LOAD_ANIM_NONE, 0, 0, &ui_Connections_screen_init);
+    }
+}
+
+void ui_event_BTStatusDisconn(lv_event_t * e)
+{
+    lv_event_code_t event_code = lv_event_get_code(e);
+    if(event_code == LV_EVENT_CLICKED) {
+        _ui_screen_change(&ui_Connections, LV_SCR_LOAD_ANIM_NONE, 0, 0, &ui_Connections_screen_init);
+    }
     if(event_code == LV_EVENT_LONG_PRESSED) {
         BTBondsClearRequest(e);
+    }
+}
+
+void ui_event_USBStatusOK(lv_event_t * e)
+{
+    lv_event_code_t event_code = lv_event_get_code(e);
+
+    if(event_code == LV_EVENT_CLICKED) {
+        _ui_screen_change(&ui_Connections, LV_SCR_LOAD_ANIM_NONE, 0, 0, &ui_Connections_screen_init);
+    }
+}
+
+void ui_event_USBStatusFail(lv_event_t * e)
+{
+    lv_event_code_t event_code = lv_event_get_code(e);
+
+    if(event_code == LV_EVENT_CLICKED) {
+        _ui_screen_change(&ui_Connections, LV_SCR_LOAD_ANIM_NONE, 0, 0, &ui_Connections_screen_init);
+    }
+}
+
+void ui_event_WiFiStatusConn(lv_event_t * e)
+{
+    lv_event_code_t event_code = lv_event_get_code(e);
+
+    if(event_code == LV_EVENT_CLICKED) {
+        _ui_screen_change(&ui_Connections, LV_SCR_LOAD_ANIM_NONE, 0, 0, &ui_Connections_screen_init);
+    }
+}
+
+void ui_event_WiFiStatusDisconn(lv_event_t * e)
+{
+    lv_event_code_t event_code = lv_event_get_code(e);
+
+    if(event_code == LV_EVENT_CLICKED) {
+        _ui_screen_change(&ui_Connections, LV_SCR_LOAD_ANIM_NONE, 0, 0, &ui_Connections_screen_init);
     }
 }
 
@@ -964,6 +1027,15 @@ void ui_event_CloseImage(lv_event_t * e)
     }
 }
 
+void ui_event_HomeButton(lv_event_t * e)
+{
+    lv_event_code_t event_code = lv_event_get_code(e);
+
+    if(event_code == LV_EVENT_CLICKED) {
+        _ui_screen_change(&ui_Screen1, LV_SCR_LOAD_ANIM_NONE, 0, 0, &ui_Screen1_screen_init);
+    }
+}
+
 ///////////////////// SCREENS ////////////////////
 
 void ui_init(void)
@@ -974,6 +1046,7 @@ void ui_init(void)
     lv_disp_set_theme(dispp, theme);
     ui_Screen1_screen_init();
     ui_Settings_screen_init();
+    ui_Connections_screen_init();
     ui____initial_actions0 = lv_obj_create(NULL);
     lv_disp_load_scr(ui_Screen1);
 }

--- a/source/main/ui_generated/ui.h
+++ b/source/main/ui_generated/ui.h
@@ -48,12 +48,17 @@ void ui_event_SettingsImage(lv_event_t * e);
 extern lv_obj_t * ui_SettingsImage;
 extern lv_obj_t * ui_TopPanel;
 extern lv_obj_t * ui_IKLogo;
+void ui_event_BTStatusConn(lv_event_t * e);
 extern lv_obj_t * ui_BTStatusConn;
 void ui_event_BTStatusDisconn(lv_event_t * e);
 extern lv_obj_t * ui_BTStatusDisconn;
+void ui_event_USBStatusOK(lv_event_t * e);
 extern lv_obj_t * ui_USBStatusOK;
+void ui_event_USBStatusFail(lv_event_t * e);
 extern lv_obj_t * ui_USBStatusFail;
+void ui_event_WiFiStatusConn(lv_event_t * e);
 extern lv_obj_t * ui_WiFiStatusConn;
+void ui_event_WiFiStatusDisconn(lv_event_t * e);
 extern lv_obj_t * ui_WiFiStatusDisconn;
 extern lv_obj_t * ui_ProjectHeadingLabel;
 extern lv_obj_t * ui_Skins;
@@ -76,6 +81,18 @@ extern lv_obj_t * ui_EntryKeyboard;
 void ui_event_OKTick(lv_event_t * e);
 extern lv_obj_t * ui_OKTick;
 // CUSTOM VARIABLES
+
+// SCREEN: ui_Connections
+void ui_Connections_screen_init(void);
+extern lv_obj_t * ui_Connections;
+void ui_event_HomeButton(lv_event_t * e);
+extern lv_obj_t * ui_HomeButton;
+extern lv_obj_t * ui_WiFiLabel;
+extern lv_obj_t * ui_WiFiSwitch;
+extern lv_obj_t * ui_BluetoothLabel;
+extern lv_obj_t * ui_BTSwitch;
+extern lv_obj_t * ui_USBLabel;
+extern lv_obj_t * ui_USBSwitch;
 
 // SCREEN: ui_Settings
 void ui_Settings_screen_init(void);


### PR DESCRIPTION
## Summary
- add new Connectivity settings page with WiFi, Bluetooth and USB toggles
- make status icons clickable to open the new page
- add home button to return to main screen

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f0ba591883298ab3e319bc1d31a7